### PR TITLE
Don't require valid github ssh key for fetching rabbit_common dependency

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,2 +1,2 @@
-{deps, [{rabbit_common, ".*", {git, "git@github.com:olgeni/rabbit_common.git", "3.2.4"}}]}.
+{deps, [{rabbit_common, ".*", {git, "https://github.com/olgeni/rabbit_common.git", "3.2.4"}}]}.
 {erl_opts, [debug_info]}.


### PR DESCRIPTION
Hi.
Don't annoy user without real need )
